### PR TITLE
Fix tokenization, masking, and labels

### DIFF
--- a/examples/train.py
+++ b/examples/train.py
@@ -37,7 +37,9 @@ def main():
 
     # tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.bos_token = "<|im_start|>"
+    tokenizer.eos_token = "<|im_end|>"
+    tokenizer.pad_token = "<|endoftext|>"
 
     # config and model
     config = CoconutConfig.from_tokenizer(
@@ -55,7 +57,7 @@ def main():
     # Set up training arguments
     training_args = TrainingArguments(
         output_dir=output_dir,
-        per_device_train_batch_size=16,
+        per_device_train_batch_size=1,
         gradient_accumulation_steps=1,
         learning_rate=1e-4,
         warmup_ratio=0.1,

--- a/opencoconut/dataset.py
+++ b/opencoconut/dataset.py
@@ -60,12 +60,9 @@ class CoTDataset(Dataset):
             answer=item["answer"],
         )
 
-        # Calculate effective max_length
-        max_len = self.max_length - self.coconut_config.continuous_thoughts * self.current_stage
-
         tokenized = self.tokenizer.encode_plus(
             prompt_formatted,
-            max_length=max_len,
+            max_length=self.max_length,
             add_special_tokens=True,
             padding="max_length",
             truncation=True,

--- a/opencoconut/dataset.py
+++ b/opencoconut/dataset.py
@@ -4,6 +4,10 @@ from datasets import load_dataset
 from torch.utils.data import Dataset
 from transformers import PreTrainedTokenizer
 
+# NOTE: cannot support \n between eos1 and bot yet
+CHATML_LIKE_FORMAT = "{bos}\n{question}{eos}{bot}{eot}\n{cot_steps}\n{answer}{eos}"
+
+
 class CoTDataset(Dataset):
     def __init__(
         self,
@@ -13,7 +17,7 @@ class CoTDataset(Dataset):
         current_stage=0,
         max_length=512,
         include_reasoning_steps=True,
-        prompt_format="{question}{bot}{eot}\n{cot_steps}\n{answer}",
+        prompt_format=CHATML_LIKE_FORMAT,
     ):
         self.dataset = load_dataset(dataset_name, split="train")
         self.tokenizer = tokenizer
@@ -32,16 +36,24 @@ class CoTDataset(Dataset):
         # Decide whether to use the current stage or a different stage
         if random.random() < self.coconut_config.mix_prob and self.current_stage != 0:
             # Choose a random stage (excluding the current stage, which is self.k)
-            self.current_stage = random.choice([i for i in range(1, self.coconut_config.stages, 1) if i != self.current_stage])
+            self.current_stage = random.choice(
+                [
+                    i
+                    for i in range(1, self.coconut_config.stages, 1)
+                    if i != self.current_stage
+                ]
+            )
         else:
             self.current_stage = self.current_stage  # Use the current stage
 
         prompt_formatted = self.prompt_format.format(
+            bos=self.tokenizer.bos_token,
             question=item["question"],
+            eos=self.tokenizer.eos_token,
             bot=self.coconut_config.bot,
             eot=self.coconut_config.eot,
             cot_steps=(
-                "\n".join(item["cot"][self.current_stage:])
+                "\n".join(item["cot"][self.current_stage :])
                 if self.include_reasoning_steps
                 else ""
             ),
@@ -49,9 +61,10 @@ class CoTDataset(Dataset):
         )
 
         # Tokenize prompts without padding
-        tokenized = self.tokenizer(
+        tokenized = self.tokenizer.encode_plus(
             prompt_formatted,
             max_length=self.max_length,
+            add_special_tokens=True,
             padding="max_length",
             truncation=True,
             return_tensors="pt",
@@ -62,7 +75,9 @@ class CoTDataset(Dataset):
         labels = input_ids.clone()
 
         # Mask question and thought tokens
-        eot_positions = (input_ids == self.coconut_config.eot_id).nonzero(as_tuple=True)[0]
+        eot_positions = (input_ids == self.coconut_config.eot_id).nonzero(
+            as_tuple=True
+        )[0]
         if len(eot_positions) > 0:
             eot_pos = eot_positions[0]  # Position of the first <eot> token
             labels[: eot_pos + 1] = -100  # Mask up to and including <eot>
@@ -93,6 +108,11 @@ def split_sequences(
         bot_id: Token ID for <bot>.
         eot_id: Token ID for <eot>.
     """
+    if input_ids.dim() == 1:
+        input_ids = input_ids.unsqueeze(0)
+        attention_mask = attention_mask.unsqueeze(0)
+        labels = labels.unsqueeze(0)
+
     batch_size = len(input_ids)
     latent_ids = []
     language_ids = []
@@ -103,8 +123,12 @@ def split_sequences(
 
     for i in range(batch_size):
         # Find positions of delimiter tokens in input_ids
-        bot_positions = (input_ids[i] == coconut_config.bot_id).nonzero(as_tuple=True)[0]
-        eot_positions = (input_ids[i] == coconut_config.eot_id).nonzero(as_tuple=True)[0]
+        bot_positions = (input_ids[i] == coconut_config.bot_id).nonzero(as_tuple=True)[
+            0
+        ]
+        eot_positions = (input_ids[i] == coconut_config.eot_id).nonzero(as_tuple=True)[
+            0
+        ]
 
         if len(bot_positions) > 0 and len(eot_positions) > 0:
             # Take first occurrence of each token
@@ -151,3 +175,47 @@ def split_sequences(
         latent_labels,
         language_labels,
     )
+
+
+if __name__ == "__main__":
+    from transformers import AutoTokenizer
+    from opencoconut import CoconutConfig
+
+    model_name = "Qwen/Qwen2.5-0.5B"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    tokenizer.bos_token = "<|im_start|>"
+    tokenizer.eos_token = "<|im_end|>"
+    tokenizer.pad_token = "<|endoftext|>"
+
+    config = CoconutConfig.from_tokenizer(
+        tokenizer,
+        stages=4,
+        continuous_thoughts=2,
+    )
+    dataset = CoTDataset(
+        "casperhansen/gsm8k_synthetic_cot",
+        tokenizer,
+        max_length=512,
+        coconut_config=config,
+        current_stage=3,
+    )
+    batch = next(iter(dataset))
+    (
+        thought_ids,
+        language_ids,
+        thought_mask,
+        language_mask,
+        thought_labels,
+        language_labels,
+    ) = split_sequences(**batch, coconut_config=config)
+
+    formatted_output = " ".join(
+        f"<{id}> ({mask})"
+        for id, mask in zip(language_ids[0].tolist(), language_mask[0].tolist())
+    )
+    print(formatted_output)
+    print(tokenizer.decode(thought_ids[0]), end="")
+    print(
+        tokenizer.decode(language_ids[0]).replace(tokenizer.pad_token, "")
+    )  # NOTE: avoid printing all the padding tokens

--- a/opencoconut/dataset.py
+++ b/opencoconut/dataset.py
@@ -60,10 +60,12 @@ class CoTDataset(Dataset):
             answer=item["answer"],
         )
 
-        # Tokenize prompts without padding
+        # Calculate effective max_length
+        max_len = self.max_length - self.coconut_config.continuous_thoughts * self.current_stage
+
         tokenized = self.tokenizer.encode_plus(
             prompt_formatted,
-            max_length=self.max_length,
+            max_length=max_len,
             add_special_tokens=True,
             padding="max_length",
             truncation=True,

--- a/opencoconut/models/qwen2.py
+++ b/opencoconut/models/qwen2.py
@@ -315,8 +315,7 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
 
             inputs_embeds = self.get_input_embeddings()(language_ids)
 
-            # the thoughts are hidden in latent space and always takes up +1 in the sequence length dimension
-            # we fix the mask and labels by inserting between <bot><eot>
+            # we fix the mask and labels lengths by inserting between <bot><eot>
             insert_idx = (input_ids == self.coconut_config.eot_id).nonzero(as_tuple=True)[1][0]
             
             attention_mask = torch.cat((

--- a/opencoconut/models/qwen2.py
+++ b/opencoconut/models/qwen2.py
@@ -328,7 +328,7 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
             # Standard forward pass
             outputs = super().forward(
                 input_ids=input_ids,
-                attention_mask=language_mask,
+                attention_mask=attention_mask,
                 position_ids=position_ids,
                 past_key_values=past_key_values,
                 inputs_embeds=None,

--- a/opencoconut/models/qwen2.py
+++ b/opencoconut/models/qwen2.py
@@ -345,6 +345,9 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
             attention_mask = torch.stack(new_attention_mask, dim=0)
             labels = torch.stack(new_labels, dim=0)
 
+            # FIXME: cannot reuse past_key_values from generating thoughts
+            past_key_values = DynamicCache()
+
             # Forward pass with combined embeddings
             outputs = super().forward(
                 input_ids=None,

--- a/opencoconut/models/qwen2.py
+++ b/opencoconut/models/qwen2.py
@@ -285,14 +285,23 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
             inputs_embeds = self.get_input_embeddings()(language_ids)
             # FIXME: when reasoning in latent space, we always have +1 to mask
             # because of the last hidden states, but no corresponding input_ids being available.
-            # SO we need to insert a zero at the correct index to mask it
+            # SO we need to insert a 0/-100 at the correct index to mask AND label it
             # (currently, this is not correctly inserted since it's just at the end)
+            # TODO: get thought position (between <bot><eot>) and insert attention_mask with 0
             attention_mask = torch.cat((
                 attention_mask,
                 torch.zeros(
                     (language_mask.shape[0], 1),
                     dtype=language_mask.dtype,
                     device=language_mask.device,
+                ),
+            ), dim=1)
+            labels = torch.cat((
+                labels,
+                torch.Tensor(
+                    (labels.shape[0], -100),
+                    dtype=labels.dtype,
+                    device=labels.device,
                 ),
             ), dim=1)
             # print(input_ids[0].shape, attention_mask[0].shape)

--- a/opencoconut/models/qwen2.py
+++ b/opencoconut/models/qwen2.py
@@ -283,12 +283,17 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
                     all_thought_outputs.append(self.hidden_states_to_token(current_hidden, lm_head=True))
 
             inputs_embeds = self.get_input_embeddings()(language_ids)
+            masked_question_and_thoughts = torch.zeros(
+                (language_ids.shape[0], thought_ids.shape[1]),
+                dtype=language_mask.dtype,
+                device=language_mask.device,
+            )
+            attention_mask = torch.cat((thought_mask, masked_question_and_thoughts, language_mask), dim=1)
             cache_position = torch.arange(
                 cache_position[-1].item(), cache_position[-1].item() + language_ids.shape[1],
                 dtype=cache_position.dtype,
                 device=cache_position.device,
             )
-            attention_mask = torch.cat((torch.ones((language_ids.shape[0], cache_position[-1].item()), device=language_ids.device), language_mask), dim=1)
 
             # Forward pass with combined embeddings
             outputs = super().forward(
@@ -307,12 +312,18 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
             )
 
             if self.debug:
+                # FIXME: we are off by 1, but 2 thoughts are generated
+                # print(input_ids.shape, attention_mask.shape)
+                # print(" ".join(
+                #     f"<{self.tokenizer.decode(id)}> ({mask})"
+                #     for id, mask in zip(input_ids[0].tolist(), attention_mask[0].tolist())
+                # ))
                 self._print_thought_and_final_tokens(outputs.logits, all_thought_outputs)
         else:
             # Standard forward pass
             outputs = super().forward(
                 input_ids=input_ids,
-                attention_mask=attention_mask,
+                attention_mask=language_mask,
                 position_ids=position_ids,
                 past_key_values=past_key_values,
                 inputs_embeds=None,

--- a/opencoconut/models/qwen2.py
+++ b/opencoconut/models/qwen2.py
@@ -295,11 +295,14 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
                 current_hidden = outputs.hidden_states[-1][:, -1:, :]
                 # The inputs for the next thought will be the current hidden state
                 inputs_embeds = current_hidden
-                thought_mask = torch.ones(
-                    (current_hidden.shape[0], 1),
-                    dtype=thought_mask.dtype,
-                    device=thought_mask.device,
-                )
+                thought_mask = torch.cat((
+                    thought_mask,
+                    torch.ones(
+                        (current_hidden.shape[0], 1),
+                        dtype=thought_mask.dtype,
+                        device=thought_mask.device,
+                    ),
+                ), dim=1)
                 # Update cache_position for the next thought
                 cache_position = torch.tensor(
                     [cache_position[-1] + 1],
@@ -360,11 +363,7 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
             if self.debug:
                 tokens = []
                 for i, (id, mask, label) in enumerate(
-                    zip(
-                        input_ids[0].tolist(),
-                        attention_mask[0].tolist(),
-                        labels[0].tolist(),
-                    )
+                    zip(input_ids[0].tolist(), attention_mask[0].tolist(), labels[0].tolist())
                 ):
                     tokens.append(f"<{self.tokenizer.decode(id)}> ({mask}, {label})")
                     if i == insert_idx:

--- a/opencoconut/models/qwen2.py
+++ b/opencoconut/models/qwen2.py
@@ -292,18 +292,16 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
                 )
 
                 past_key_values = outputs.past_key_values
-                current_hidden = outputs.hidden_states[-1][:, -1:, :]
                 # The inputs for the next thought will be the current hidden state
-                inputs_embeds = current_hidden
+                inputs_embeds = outputs.hidden_states[-1][:, -1:, :]
                 thought_mask = torch.cat((
                     thought_mask,
                     torch.ones(
-                        (current_hidden.shape[0], 1),
+                        (inputs_embeds.shape[0], 1),
                         dtype=thought_mask.dtype,
                         device=thought_mask.device,
                     ),
                 ), dim=1)
-                # Update cache_position for the next thought
                 cache_position = torch.tensor(
                     [cache_position[-1] + 1],
                     dtype=cache_position.dtype,
@@ -312,7 +310,7 @@ class CoconutQwen2ForCausalLM(Qwen2ForCausalLM):
 
                 if self.debug:
                     all_thought_outputs.append(
-                        self.hidden_states_to_token(current_hidden, lm_head=True)
+                        self.hidden_states_to_token(inputs_embeds, lm_head=True)
                     )
 
             inputs_embeds = self.get_input_embeddings()(language_ids)


### PR DESCRIPTION
Features/fixes:
- Use ChatML-like format for training
- Fix not using BOS and EOS when tokenizing
- get thought position (between `<bot><eot>`) and insert at the thought position in BOTH attention_mask and labels
- when `DEBUG=1`, the `input_ids` will be 512 and `attention_mask` 513. insert `[THOUGHT]` into `input_ids` as one token in debug mode and correctly print the `attention_mask` or `labels` for the `input_ids`
- fix inference with new format and way of processing attention_mask
- make it compatible with a batch size > 1 (`max_len` in dataset and `attention_mask`/`labels` in both forwards.)

Can't/won't fix:
- Using `past_key_values` from thought-loop in the final forward